### PR TITLE
Changed BUS_TYPE name

### DIFF
--- a/loggers/logger_can.py
+++ b/loggers/logger_can.py
@@ -4,7 +4,7 @@ from addresses import ECU_ADDRESSES, TARGET_ADDRESSES
 
 LOG_TYPE = "can"
 
-BUS_TYPE = "socketcan_native"
+BUS_TYPE = "socketcan"
 
 CAN_MASK = 0x7FF
 


### PR DESCRIPTION
Looks like the python-can library changed the name of the device from "socketcan_native" to "socketcan"

Error of the device not found:

OSError: [Errno 19] No such device
    raise CanInterfaceNotImplementedError(
can.exceptions.CanInterfaceNotImplementedError: **Unknown interface type "socketcan_native"**
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/owl/ecu-simulator/obd/listener.py", line 11, in start
    request_socket = create_isotp_socket(OBD_BROADCAST_ADDRESS, OBD_TARGET_ADDRESS)
  File "/home/owl/ecu-simulator/obd/listener.py", line 26, in create_isotp_socket
    socket.bind(CAN_INTERFACE, isotp.Address(rxid=receiver_address, txid=target_address))
  File "/usr/local/lib/python3.10/dist-packages/isotp/tpsock/__init__.py", line 168, in bind
    self._socket.bind((interface, rxid, txid))
OSError: [Errno 19] No such device


My ecu_config.json:

```
{
  "vin": {
    "value": "TESTVIN0123456789",
    "description": "Vehicle Identification Number. Max 17 characters"
  },
  "ecu_name": {
    "value": "ECU_SIMULATOR",
    "description": "Name of the ECU. Max 20 characters"
  },
  "fuel_level": {
    "value": 50,
    "description": "Fuel Level. Between 0 and 100"
  },
  "fuel_type": {
    "value": 1,
    "description": "Fuel type (e.g., 1=Gasoline). See https://en.wikipedia.org/wiki/OBD-II_PIDs#Fuel_Type_Coding"
  },
  "dtcs": {
    "value": ["B1477", "P0001"],
    "description": "List of Diagnostic Trouble Codes. The list can contain Max 255 DTCs"
  },
  "obd_broadcast_address": {
    "value": "0x7DF",
    "description": "11-Bit broadcast address the ECU uses to receive OBD requests (functional addressing). The target address is: obd_ecu_address + 0x8"
  },
  "obd_ecu_address": {
    "value": "0x7E0",
    "description": "11-Bit physical address the ECU uses to response to an OBD request. The target address is: obd_ecu_address + 0x8"
  },
  "uds_ecu_address": {
    "value": "0x7E1",
    "description": "11-Bit physical address the ECU uses to receive and response to an UDS request (physical addressing). The target address is: uds_ecu_address + 0x8. The UDS module does not use functional addressing"
  },
  "can_interface": {
    "value": "can0",
    "description": "CAN Interface used by the ECU simulator"
  },
  "can_interface_type": {
    "value": "hardware",
    "description": "Two types are possible: virtual and hardware. If any other value is provided, the ecu-simulator does not set up the CAN interface and ISO-TP linux kernel module"
  },
  "can_bitrate": {
    "value": "500000",
    "description": "CAN bitrate (refer to the specification of your CAN hardware). Only applicable for can_interface_type: hardware"
  },
  "isotp_ko_file_path": {
    "value": "/usr/lib/modules/5.19.0-32-generic/kernel/net/can/can-isotp.ko",
    "description": "File path of the ISO-TP Kernel module (see https://github.com/hartkopp/can-isotp)"
  }
}

```